### PR TITLE
Use dirname(@__FILE__) instead of Pkg.dir

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ os:
 
 julia:
   - 0.4
+  - 0.5
   - nightly
 
 notifications:

--- a/test/coverage.jl
+++ b/test/coverage.jl
@@ -5,6 +5,6 @@ get(ENV, "TRAVIS_JULIA_VERSION", "") == "nightly" || exit()
 Pkg.add("Coverage")
 using Coverage
 
-cd(Pkg.dir("PrivateModules")) do
+cd(joinpath(dirname(@__FILE__),"..")) do
     Codecov.submit(Codecov.process_folder())
 end


### PR DESCRIPTION
This allows installing the package elsewhere.

Add testing against 0.5 to Travis - this runs the most
recent RC now, release once final tags are done
